### PR TITLE
Add SafePrime initial implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ extern crate test;
 
 mod prime;
 pub use prime::Prime;
+pub use prime::SafePrime;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
See #3.

This currently utilizes a naive prime generation method. It may be of some interest to replace this algorithm with one that is quicker, such as mentioned [here](https://www.iacr.org/archive/ches2006/13/13.pdf) at some point in the future (some small weaknesses addressed in a follow up paper).

(I'm working on a GMP version of this and IF I eventually finish, I'll probably port it to Rust).